### PR TITLE
Serialization error when using plugin in a mutli-host environment.

### DIFF
--- a/src/main/java/crate/elasticsearch/facet/distinct/StringDistinctDateHistogramFacetExecutor.java
+++ b/src/main/java/crate/elasticsearch/facet/distinct/StringDistinctDateHistogramFacetExecutor.java
@@ -158,7 +158,7 @@ public class StringDistinctDateHistogramFacetExecutor extends FacetExecutor {
 
             @Override
             protected void onValue(int docId, BytesRef value, int hashCode, BytesValues values) {
-                entry.getValues().add(value);
+                entry.getValues().add(value.utf8ToString());
             }
         }
     }


### PR DESCRIPTION
# Issue

The facet collector is putting BytesRef objects into the DistinctEntry set.  The serialization is casting these to strings and calling write-string. (see https://github.com/crate/elasticsearch-timefacets-plugin/blob/master/src/main/java/crate/elasticsearch/facet/distinct/StringInternalDistinctDateHistogramFacet.java#L98)
# Fix

This pull request converts the BytesRefs to a string when pushing them into the set. 
# Notes

I'm not sure if the approach take in this pull request is the best approach, but it does work. It might be better to write and read the serialization as a BytesRef instead of doing the early conversion, but hopefully this helps isolate the bug.
