### PR TITLE
Elasticsearch 0.90.7 compatability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     </parent>
 
     <properties>
-        <elasticsearch.version>0.90.5</elasticsearch.version>
+        <elasticsearch.version>0.90.7</elasticsearch.version>
     </properties>
 
     <distributionManagement>

--- a/src/main/java/crate/elasticsearch/facet/distinct/DistinctDateHistogramFacetParser.java
+++ b/src/main/java/crate/elasticsearch/facet/distinct/DistinctDateHistogramFacetParser.java
@@ -3,14 +3,13 @@ package crate.elasticsearch.facet.distinct;
 import org.elasticsearch.common.collect.ImmutableMap;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.component.AbstractComponent;
+import org.elasticsearch.common.hppc.ObjectIntOpenHashMap;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.joda.time.Chronology;
 import org.elasticsearch.common.joda.time.DateTimeField;
 import org.elasticsearch.common.joda.time.DateTimeZone;
 import org.elasticsearch.common.joda.time.MutableDateTime;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.trove.impl.Constants;
-import org.elasticsearch.common.trove.map.hash.TObjectIntHashMap;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
@@ -34,7 +33,7 @@ import java.io.IOException;
 public class DistinctDateHistogramFacetParser extends AbstractComponent implements FacetParser {
 
     private final ImmutableMap<String, DateFieldParser> dateFieldParsers;
-    private final TObjectIntHashMap<String> rounding = new TObjectIntHashMap<String>(Constants.DEFAULT_CAPACITY, Constants.DEFAULT_LOAD_FACTOR, -1);
+    private final ObjectIntOpenHashMap<String> rounding = new ObjectIntOpenHashMap<String>();
 
     @Inject
     public DistinctDateHistogramFacetParser(Settings settings) {

--- a/src/main/java/crate/elasticsearch/facet/distinct/LongInternalDistinctDateHistogramFacet.java
+++ b/src/main/java/crate/elasticsearch/facet/distinct/LongInternalDistinctDateHistogramFacet.java
@@ -4,12 +4,13 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.HashedBytesArray;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.trove.ExtTLongObjectHashMap;
 import org.elasticsearch.search.facet.Facet;
 
 import java.io.IOException;
-import java.util.*;
-import org.elasticsearch.cache.recycler.CacheRecycler;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 public class LongInternalDistinctDateHistogramFacet extends InternalDistinctDateHistogramFacet {
 

--- a/src/main/java/crate/elasticsearch/facet/distinct/StringInternalDistinctDateHistogramFacet.java
+++ b/src/main/java/crate/elasticsearch/facet/distinct/StringInternalDistinctDateHistogramFacet.java
@@ -5,7 +5,6 @@ import org.elasticsearch.common.bytes.HashedBytesArray;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.recycler.Recycler;
-import org.elasticsearch.common.trove.ExtTLongObjectHashMap;
 import org.elasticsearch.search.facet.Facet;
 import org.elasticsearch.search.facet.InternalFacet;
 

--- a/src/main/java/crate/elasticsearch/facet/latest/InternalLatestFacet.java
+++ b/src/main/java/crate/elasticsearch/facet/latest/InternalLatestFacet.java
@@ -3,10 +3,10 @@ package crate.elasticsearch.facet.latest;
 import org.apache.lucene.util.PriorityQueue;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.HashedBytesArray;
+import org.elasticsearch.common.hppc.LongObjectOpenHashMap;
+import org.elasticsearch.common.hppc.procedures.LongObjectProcedure;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.trove.map.TLongObjectMap;
-import org.elasticsearch.common.trove.procedure.TLongObjectProcedure;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.search.facet.Facet;
@@ -89,16 +89,15 @@ public class InternalLatestFacet extends InternalFacet {
         }
     }
 
-    public void insert(TLongObjectMap<InternalLatestFacet.Entry> entries) {
+    public void insert(LongObjectOpenHashMap<Entry> entries) {
         if (queue == null) {
             this.queue = new EntryPriorityQueue(start + size);
         }
-        entries.forEachEntry(new TLongObjectProcedure<Entry>() {
+        entries.forEach(new LongObjectProcedure<Entry>() {
             @Override
-            public boolean execute(long key, Entry entry) {
+            public void apply(long key, Entry entry) {
                 entry.key = key;
                 queue.insertWithOverflow(entry);
-                return true;
             }
         });
     }

--- a/src/main/java/crate/elasticsearch/facet/latest/LatestFacetExecutor.java
+++ b/src/main/java/crate/elasticsearch/facet/latest/LatestFacetExecutor.java
@@ -2,8 +2,8 @@ package crate.elasticsearch.facet.latest;
 
 import org.apache.lucene.index.AtomicReaderContext;
 import org.elasticsearch.cache.recycler.CacheRecycler;
+import org.elasticsearch.common.hppc.LongObjectOpenHashMap;
 import org.elasticsearch.common.recycler.Recycler;
-import org.elasticsearch.common.trove.ExtTLongObjectHashMap;
 import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.fielddata.LongValues;
@@ -27,7 +27,7 @@ public class LatestFacetExecutor extends FacetExecutor {
     protected int size = 10;
     protected int start = 0;
 
-    final Recycler.V<ExtTLongObjectHashMap<InternalLatestFacet.Entry>> entries;
+    final Recycler.V<LongObjectOpenHashMap<InternalLatestFacet.Entry>> entries;
 
     public LatestFacetExecutor(IndexNumericFieldData keyField, IndexNumericFieldData valueField,
                                IndexNumericFieldData tsField, int size, int start, CacheRecycler cacheRecycler) {
@@ -80,20 +80,22 @@ public class LatestFacetExecutor extends FacetExecutor {
 
     public static class Aggregator extends LongFacetAggregatorBase {
 
-        final ExtTLongObjectHashMap<InternalLatestFacet.Entry> entries;
+        final LongObjectOpenHashMap<InternalLatestFacet.Entry> entries;
 
         LongValues valueValues;
         LongValues tsValues;
-        public Aggregator(ExtTLongObjectHashMap<InternalLatestFacet.Entry> entries){
+        public Aggregator(LongObjectOpenHashMap<InternalLatestFacet.Entry> entries){
             this.entries = entries;
         }
 
         @Override
         public void onValue(int docId, long key) {
             InternalLatestFacet.Entry entry = entries.get(key);
-            long ts = tsValues.getValue(docId);
+            tsValues.setDocument(docId);
+            long ts = tsValues.nextValue();
             if (entry == null || entry.ts < ts) {
-                int value = (int)valueValues.getValue(docId);
+                valueValues.setDocument(docId);
+                int value = (int)valueValues.nextValue();
                 if (entry == null) {
                     entry = new InternalLatestFacet.Entry(ts, value);
                     entries.put(key, entry);


### PR DESCRIPTION
Added compatibility with ES 0.90.7 

This change moves from trove to hppc based implementation and closes issue #16.
